### PR TITLE
add Support for sudo / finding nvme tool in different places / ignore num_err_log_entries

### DIFF
--- a/check_nvme.sh
+++ b/check_nvme.sh
@@ -31,6 +31,11 @@ USAGE="Usage: check_nvme.sh [-s] [-e] -d <device>
 "
 DISK=""
 SUDO=""
+if [ -x /usr/sbin/nvme ]; then
+    NVME=/usr/sbin/nvme
+else
+    NVME=nvme
+fi
 
 while getopts ":sed:" OPTS; do
   case $OPTS in
@@ -50,7 +55,7 @@ fi
 
 
 # read smart information from nvme-cli
-LOG=$(${SUDO} nvme smart-log ${DISK})
+LOG=$(${SUDO} ${NVME} smart-log ${DISK})
 
 MESSAGE=""
 CRIT=false

--- a/check_nvme.sh
+++ b/check_nvme.sh
@@ -25,15 +25,17 @@ export LC_ALL=C
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-USAGE="Usage: check_nvme.sh [-s] -d <device>
+USAGE="Usage: check_nvme.sh [-s] [-e] -d <device>
   -s .. call nvme smart-log using sudo
+  -e .. ignore num_err_log_entries for state
 "
 DISK=""
 SUDO=""
 
-while getopts ":sd:" OPTS; do
+while getopts ":sed:" OPTS; do
   case $OPTS in
     s) SUDO="sudo";;
+    e) IGNORE_ERR_LOG_ENTRIES="1";;
     d) DISK="$OPTARG";;
     *) echo "$USAGE"
        exit 3;;
@@ -70,7 +72,9 @@ fi
 # Check number of errors logged
 value_num_err_log=$(echo "$LOG" | awk '$1 == "num_err_log_entries" {print $3}')
 if [ $value_num_err_log != 0 ]; then
-  CRIT=true
+  if [ -z ${IGNORE_ERR_LOG_ENTRIES+USET} ]; then
+    CRIT=true
+  fi
   MESSAGE="$MESSAGE $DISK has errors logged ($value_num_err_log) "
 fi
 

--- a/check_nvme.sh
+++ b/check_nvme.sh
@@ -25,11 +25,15 @@ export LC_ALL=C
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-USAGE="Usage: check_nvme.sh -d <device>"
+USAGE="Usage: check_nvme.sh [-s] -d <device>
+  -s .. call nvme smart-log using sudo
+"
 DISK=""
+SUDO=""
 
-while getopts ":d:" OPTS; do
+while getopts ":sd:" OPTS; do
   case $OPTS in
+    s) SUDO="sudo";;
     d) DISK="$OPTARG";;
     *) echo "$USAGE"
        exit 3;;
@@ -42,8 +46,9 @@ then
   exit 3
 fi
 
+
 # read smart information from nvme-cli
-LOG=$(nvme smart-log ${DISK})
+LOG=$(${SUDO} nvme smart-log ${DISK})
 
 MESSAGE=""
 CRIT=false


### PR DESCRIPTION
The first patch "add sudo support" adds the optional command line option `-s`
If it is set, `sudo nvme smart-log` is called instead of `nvme smart-log`

When sudo is used, the nvme tool, which is usually located in /usr/sbin,
is not found. This patch searches explicitly at this location.

Some SSDs generate an error-log entry every time they are initialized.
This patch adds the -e option and ensures that error log entries do not cause the test to become critical.

the patches are very small and overlap so 3 different pull requests wouldnt work.